### PR TITLE
Tick diffing to check all properties that impact the rendered result

### DIFF
--- a/lib/ticks.js
+++ b/lib/ticks.js
@@ -63,7 +63,15 @@ function ticksEqual(ticksA, ticksB) {
     for(var j=0; j<ticksA[i].length; ++j) {
       var a = ticksA[i][j]
       var b = ticksB[i][j]
-      if(a.x !== b.x || a.text !== b.text) {
+      if(
+        a.x !== b.x ||
+        a.text !== b.text ||
+        a.font !== b.font ||
+        a.fontColor !== b.fontColor ||
+        a.fontSize !== b.fontSize ||
+        a.dx !== b.dx ||
+        a.dy !== b.dy
+      ) {
         return false
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gl-axes3d",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "3D axes for WebGL",
   "main": "axes.js",
   "directories": {


### PR DESCRIPTION
Without this change, e.g. a font family change will yield equality of ticks, therefore a font family update will not lead to a change to what's rendered.