### PR TITLE
gl-shader unlock

### DIFF
--- a/axes.js
+++ b/axes.js
@@ -448,6 +448,7 @@ proto.draw = function(params) {
       this._lines.drawAxisTicks(i, lineOffset[i].mirrorOffset, mirrorMinor, this.lineTickColor[i], this.lineTickWidth[i]*this.pixelRatio)
     }
   }
+  this._lines.unbind()
 
   //Draw text sprites
   this._text.bind(
@@ -502,6 +503,8 @@ proto.draw = function(params) {
         this.labelColor[i])
     }
   }
+
+  this._text.unbind()
 }
 
 proto.dispose = function() {

--- a/example/example.js
+++ b/example/example.js
@@ -3,7 +3,7 @@ var shell = require("gl-now")({ clearColor: [0,0,0,0] })
 var camera = require("game-shell-orbit-camera")(shell)
 
 //Mesh creation tools
-var createMesh = require("gl-simplicial-complex")
+var createMesh = require("gl-mesh3d")
 var polygonize = require("isosurface").surfaceNets
 var createAxes = require("../axes")
 
@@ -31,7 +31,7 @@ shell.on("gl-init", function() {
   mesh = createMesh(gl, polygonize([64, 64, 64], f, bounds))
 
   //Create axes object
-  axes = createAxes(gl, { 
+  axes = createAxes(gl, {
     bounds: bounds
   })
 
@@ -54,7 +54,7 @@ shell.on("gl-render", function() {
         0.1,
         1000.0)
   }
-  
+
   //Draw mesh
   mesh.draw(cameraParameters)
 

--- a/lib/background.js
+++ b/lib/background.js
@@ -40,6 +40,7 @@ proto.draw = function(model, view, projection, bounds, enable, colors) {
   }
   this.vao.bind()
   this.vao.draw(this.gl.TRIANGLES, 36)
+  this.vao.unbind()
 
   gl.disable(gl.POLYGON_OFFSET_FILL)
 }

--- a/lib/lines.js
+++ b/lib/lines.js
@@ -50,6 +50,10 @@ proto.bind = function(model, view, projection) {
   this.vao.bind()
 }
 
+proto.unbind = function() {
+  this.vao.unbind()
+}
+
 proto.drawAxisLine = function(j, bounds, offset, color, lineWidth) {
   var minorAxis = zeroVec(MINOR_AXIS)
   this.shader.uniforms.majorAxis = MINOR_AXIS

--- a/lib/text.js
+++ b/lib/text.js
@@ -51,6 +51,10 @@ proto.bind = function(model, view, projection, pixelScale) {
   this.shader.uniforms.resolution = SHAPE
 }
 
+proto.unbind = function() {
+  this.vao.unbind()
+}
+
 proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
   var gl = this.gl
   var data = []

--- a/package.json
+++ b/package.json
@@ -21,7 +21,13 @@
     "split-polygon": "^1.0.0",
     "vectorize-text": "^3.0.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "game-shell-orbit-camera": "^1.0.0",
+    "gl-matrix": "^2.3.2",
+    "gl-mesh3d": "^1.3.0",
+    "gl-now": "^1.4.0",
+    "isosurface": "^1.0.0"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "beefy --open --live example/example.js"


### PR DESCRIPTION
We have to unbind gl-vao's in order to avoid warnings in console, which was the issue preventing from bumping _gl-shader_ version. Still have to figure out why it happens so with unbound _gl-vao_, but here it is must-do patch.

TODO:
* [x] _gl-mesh3d_ _gl-shader_  can be unlocked https://github.com/gl-vis/gl-mesh3d/commit/894b14320c0bc9135a845100c98165cfdf3e0537
* [x] _gl-error3d_ _gl-shader_ can be unlocked as well https://github.com/gl-vis/gl-error3d/commit/5abf5990368e8af8f184e6c4bb0fd7985bd8b605
* [ ] _gl-shader_ direct dependency can be removed from plotly at all, there is no direct use of it https://github.com/plotly/plotly.js/pull/931
* [ ] resolve unbound gl-vao issue https://gist.github.com/dfcreative/80153fb7be5b2fd486a6c78e7bdc0f1b

Supercedes https://github.com/gl-vis/gl-axes3d/pull/10

@etpinard I can do patches to according repos to unlock _gl-shader_ version