### PR TITLE
Update of options to align axis labels and ticks in 3D scenes

### DIFF
--- a/axes.js
+++ b/axes.js
@@ -457,11 +457,24 @@ proto.draw = function(params) {
     projection,
     this.pixelRatio)
 
-  var alignOpt = [0,0,1]
-  // Note: the 3rd member is the integer option
+  var alignOption = 1
+  // Note: the 4th member is the integer option
   // from {-1, 0, 1, 2, 3, ..., n}
 
   for(var i=0; i<3; ++i) {
+
+    var alignDir = [0,0,0,alignOption]
+
+    var signViewXY = Math.sign(view[10]);
+    if (signViewXY > 0) {
+           if (i === 2) alignDir[2] = 0 // horizontal
+      else if (i === 1) alignDir[0] = 1 // align to X
+      else if (i === 0) alignDir[1] = 1 // align to Y
+    } else {
+           if (i === 2) alignDir[2] = 0 // horizontal
+      else if (i === 1) alignDir[2] = 1 // align to Z
+      else if (i === 0) alignDir[2] = 1 // align to Z
+    }
 
     var minor      = lineOffset[i].primalMinor
     var offset     = copyVec3(PRIMAL_OFFSET, lineOffset[i].primalOffset)
@@ -475,9 +488,6 @@ proto.draw = function(params) {
     var axis = [0,0,0]
     axis[i] = 1
 
-    var alignDir = [0,0,0]
-    alignDir[i] = 1
-
     //Draw tick text
     if(this.tickEnable[i]) {
 
@@ -490,27 +500,26 @@ proto.draw = function(params) {
       this._text.drawTicks(
         i,
         this.tickSize[i],
-        this.tickAngle[i] + 0.5 * Math.PI,
+        this.tickAngle[i],
         offset,
         this.tickColor[i],
         axis,
-        alignDir,
-        alignOpt)
+        alignDir)
     }
 
     //Draw labels
     if(this.labelEnable[i]) {
+
+      var alignDir = [0,0,0,alignOption]
+      if(this.labels[i].length > 4) { // for large label axis enable alignDir to axis
+        alignDir[i]  = 1
+      }
 
       //Add label padding
       for(var j=0; j<3; ++j) {
         offset[j] += pixelScaleF * minor[j] * this.labelPad[j] / model[5*j]
       }
       offset[i] += 0.5 * (bounds[0][i] + bounds[1][i])
-
-      var alignDir = [0,0,0]
-      if(this.labels[i].length > 4) { // for large label axis enable alignDir to axis
-        alignDir[i]  = 1
-      }
 
       //Draw axis
       this._text.drawLabel(
@@ -520,8 +529,7 @@ proto.draw = function(params) {
         offset,
         this.labelColor[i],
         [0,0,0],
-        alignDir,
-        alignOpt)
+        alignDir)
     }
   }
 

--- a/axes.js
+++ b/axes.js
@@ -545,7 +545,7 @@ proto.draw = function(params) {
     if(this.labelEnable[i]) {
 
       upwardsTolerance = 0; // no tolerance for titles
-      alignOpt[0] = [this.labelAlign[i], upwardsTolerance, hv_ratio]
+      alignOpt = [this.labelAlign[i], upwardsTolerance, hv_ratio]
       if(alignOpt[0] === 'auto') alignOpt[0] = 1
       else alignOpt[0] = parseInt('' + alignOpt[0])
 

--- a/axes.js
+++ b/axes.js
@@ -36,7 +36,7 @@ function Axes(gl) {
   this.tickFont       = [ 'sans-serif', 'sans-serif', 'sans-serif' ]
   this.tickSize       = [ 12, 12, 12 ]
   this.tickAngle      = [ 0, 0, 0 ]
-  this.tickAlign      = [ 'auto', 'auto', 'auto' ]
+  this._tickAlign      = [ 'auto', 'auto', 'auto' ]
   this.tickColor      = [ [0,0,0,1], [0,0,0,1], [0,0,0,1] ]
   this.tickPad        = [ 10, 10, 10 ]
 
@@ -49,8 +49,8 @@ function Axes(gl) {
   this.labelEnable    = [ true, true, true ]
   this.labelFont      = 'sans-serif'
   this.labelSize      = [ 20, 20, 20 ]
-  this.labelAngle     = [ 0, 0, 0 ]
-  this.labelAlign     = [ 'auto', 'auto', 'auto' ]
+  this._labelAngle     = [ 0, 0, 0 ]
+  this._labelAlign     = [ 'auto', 'auto', 'auto' ]
   this.labelColor     = [ [0,0,0,1], [0,0,0,1], [0,0,0,1] ]
   this.labelPad       = [ 10, 10, 10 ]
 
@@ -515,9 +515,16 @@ proto.draw = function(params) {
     //Draw tick text
     if(this.tickEnable[i]) {
 
-      upwardsTolerance = 0.25 * Math.PI; // allow downwards ticks (45 degrees)
+      upwardsTolerance = 0.0 // using a value e.g. 0.25 * Math.PI could allow downwards ticks (45 degrees)
 
-      alignOpt = [this.tickAlign[i], upwardsTolerance, hv_ratio]
+      if(this.tickAngle[i] === -3600) {
+        this.tickAngle[i] = 0
+        this._tickAlign[i] = 'auto'
+      } else {
+        this._tickAlign[i] = -1
+      }
+
+      alignOpt = [this._tickAlign[i], upwardsTolerance, hv_ratio]
       if(alignOpt[0] === 'auto') alignOpt[0] = 1
       else alignOpt[0] = parseInt('' + alignOpt[0])
 
@@ -544,8 +551,8 @@ proto.draw = function(params) {
     //Draw labels
     if(this.labelEnable[i]) {
 
-      upwardsTolerance = 0; // no tolerance for titles
-      alignOpt = [this.labelAlign[i], upwardsTolerance, hv_ratio]
+      upwardsTolerance = 0 // no tolerance for titles
+      alignOpt = [this._labelAlign[i], upwardsTolerance, hv_ratio]
       if(alignOpt[0] === 'auto') alignOpt[0] = 1
       else alignOpt[0] = parseInt('' + alignOpt[0])
 
@@ -564,7 +571,7 @@ proto.draw = function(params) {
       this._text.drawLabel(
         i,
         this.labelSize[i],
-        this.labelAngle[i],
+        this._labelAngle[i],
         offset,
         this.labelColor[i],
         [0,0,0],

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -23,7 +23,7 @@ float positive_angle(float a) {
 
 float look_upwards(float a) {
   float b = positive_angle(a);
-  if ((b > HALF_PI) && (b < ONE_AND_HALF_PI)) return b - PI;
+  if ((b > HALF_PI) && (b <= ONE_AND_HALF_PI)) return b - PI;
   return b;
 }
 

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -1,7 +1,8 @@
 attribute vec3 position;
 
 uniform mat4 model, view, projection;
-uniform vec3 offset, axis, alignDir, alignOpt;
+uniform vec3 offset, axis;
+uniform vec4 alignDir;
 uniform float scale, angle, pixelScale;
 uniform vec2 resolution;
 
@@ -51,7 +52,7 @@ float look_round_n_directions(float a, int n) {
   return look_upwards(c);
 }
 
-int option = int(floor(alignOpt.z + 0.001));
+int option = int(floor(alignDir.w + 0.001));
 
 float applyAlignOption(float rawAngle) {
 
@@ -73,25 +74,21 @@ float applyAlignOption(float rawAngle) {
   return look_round_n_directions(rawAngle, option);
 }
 
+bool enableAlign = (alignDir.x != 0.0) || (alignDir.y != 0.0) || (alignDir.z != 0.0);
+
 void main() {
 
   //Compute world offset
   float axisDistance = position.z;
   vec3 dataPosition = axisDistance * axis + offset;
 
-  float clipAngle = 0.0;
+  float clipAngle = angle; // i.e. user defined attributes for each tick
 
-  if ((alignDir.x != 0.0) ||
-      (alignDir.y != 0.0) ||
-      (alignDir.z != 0.0)) {
-
-    vec3 REF = dataPosition;
-
-    vec3 startPoint = project(REF);
-    vec3 endPoint   = project(REF + alignDir);
+  if (enableAlign) {
+    vec3 startPoint = project(dataPosition);
+    vec3 endPoint   = project(dataPosition + alignDir.xyz);
 
     clipAngle = applyAlignOption(
-      angle + // i.e. user defined attributes for each tick
       atan(
         (endPoint.y - startPoint.y) * resolution.y,
         (endPoint.x - startPoint.x) * resolution.x

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -89,7 +89,9 @@ void main() {
     vec3 startPoint = project(dataPosition);
     vec3 endPoint   = project(dataPosition + alignDir);
 
-    clipAngle = applyAlignOption(
+    if (endPoint.z < 0.0) endPoint = project(dataPosition - alignDir);
+
+    clipAngle += applyAlignOption(
       atan(
         (endPoint.y - startPoint.y) * resolution.y,
         (endPoint.x - startPoint.x) * resolution.x

--- a/lib/text.js
+++ b/lib/text.js
@@ -122,7 +122,7 @@ proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
 }
 
 //Draws the tick marks for an axis
-proto.drawTicks = function(d, scale, angle, offset, color, axis, alignDir) {
+proto.drawTicks = function(d, scale, angle, offset, color, axis, alignDir, alignOpt) {
   if(!this.tickCount[d]) {
     return
   }
@@ -133,11 +133,12 @@ proto.drawTicks = function(d, scale, angle, offset, color, axis, alignDir) {
   this.shader.uniforms.scale = scale
   this.shader.uniforms.offset = offset
   this.shader.uniforms.alignDir = alignDir
+  this.shader.uniforms.alignOpt = alignOpt
   this.vao.draw(this.gl.TRIANGLES, this.tickCount[d], this.tickOffset[d])
 }
 
 //Draws the text label for an axis
-proto.drawLabel = function(d, scale, angle, offset, color, axis, alignDir) {
+proto.drawLabel = function(d, scale, angle, offset, color, axis, alignDir, alignOpt) {
   if(!this.labelCount[d]) {
     return
   }
@@ -148,6 +149,7 @@ proto.drawLabel = function(d, scale, angle, offset, color, axis, alignDir) {
   this.shader.uniforms.scale = scale
   this.shader.uniforms.offset = offset
   this.shader.uniforms.alignDir = alignDir
+  this.shader.uniforms.alignOpt = alignOpt
   this.vao.draw(this.gl.TRIANGLES, this.labelCount[d], this.labelOffset[d])
 }
 

--- a/lib/text.js
+++ b/lib/text.js
@@ -122,7 +122,7 @@ proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
 }
 
 //Draws the tick marks for an axis
-proto.drawTicks = function(d, scale, angle, offset, color, axis, alignDir, alignOpt) {
+proto.drawTicks = function(d, scale, angle, offset, color, axis, alignDir) {
   if(!this.tickCount[d]) {
     return
   }
@@ -133,12 +133,11 @@ proto.drawTicks = function(d, scale, angle, offset, color, axis, alignDir, align
   this.shader.uniforms.scale = scale
   this.shader.uniforms.offset = offset
   this.shader.uniforms.alignDir = alignDir
-  this.shader.uniforms.alignOpt = alignOpt
   this.vao.draw(this.gl.TRIANGLES, this.tickCount[d], this.tickOffset[d])
 }
 
 //Draws the text label for an axis
-proto.drawLabel = function(d, scale, angle, offset, color, axis, alignDir, alignOpt) {
+proto.drawLabel = function(d, scale, angle, offset, color, axis, alignDir) {
   if(!this.labelCount[d]) {
     return
   }
@@ -149,7 +148,6 @@ proto.drawLabel = function(d, scale, angle, offset, color, axis, alignDir, align
   this.shader.uniforms.scale = scale
   this.shader.uniforms.offset = offset
   this.shader.uniforms.alignDir = alignDir
-  this.shader.uniforms.alignOpt = alignOpt
   this.vao.draw(this.gl.TRIANGLES, this.labelCount[d], this.labelOffset[d])
 }
 


### PR DESCRIPTION
This PR review is to enable an interactive alignment of axis ticks and titles (labels) that are long i.e. to avoid the overlap of layout descriptions with data representation: plotly/plotly.js#3077
This functionality is not applied for labels that are shorter than 4 characters e.g. 'x', 'y', 'z'.
In addition to this interactive behavior [option=1] other options could be used e.g [option=-1] to force everything horizontal (for backward compatibility), [option=0] to show raw clip angle (useful for debugging), [option=2] to have only horizontal and vertical alignments, or any number [option=3-n] for example [option=12] to have (360/12=) 30 degrees steps.
@dy @etpinard @alexcjohnson