### PR TITLE
Automatic alignment of ticks in 3D scenes (module: gl-axes3d)

### DIFF
--- a/axes.js
+++ b/axes.js
@@ -466,7 +466,6 @@ proto.draw = function(params) {
   //  2: auto align, horizontal or vertical
   //3-n: auto align, round to n directions e.g. 12 -> round to angles with 30-degree steps
 
-  var upwardsTolerance
   var hv_ratio = 0.5 // can have an effect on the ratio between horizontals and verticals when using option 2
 
   var alignDir
@@ -515,8 +514,6 @@ proto.draw = function(params) {
     //Draw tick text
     if(this.tickEnable[i]) {
 
-      upwardsTolerance = 0.0 // using a value e.g. 0.25 * Math.PI could allow downwards ticks (45 degrees)
-
       if(this.tickAngle[i] === -3600) {
         this.tickAngle[i] = 0
         this._tickAlign[i] = 'auto'
@@ -524,7 +521,7 @@ proto.draw = function(params) {
         this._tickAlign[i] = -1
       }
 
-      alignOpt = [this._tickAlign[i], upwardsTolerance, hv_ratio]
+      alignOpt = [this._tickAlign[i], hv_ratio, 0.0]
       if(alignOpt[0] === 'auto') alignOpt[0] = 1
       else alignOpt[0] = parseInt('' + alignOpt[0])
 
@@ -551,8 +548,7 @@ proto.draw = function(params) {
     //Draw labels
     if(this.labelEnable[i]) {
 
-      upwardsTolerance = 0 // no tolerance for titles
-      alignOpt = [this._labelAlign[i], upwardsTolerance, hv_ratio]
+      alignOpt = [this._labelAlign[i], hv_ratio, 0.0]
       if(alignOpt[0] === 'auto') alignOpt[0] = 1
       else alignOpt[0] = parseInt('' + alignOpt[0])
 

--- a/axes.js
+++ b/axes.js
@@ -317,6 +317,7 @@ proto.isTransparent = function() {
 
 proto.drawTransparent = function(params) {}
 
+var ALIGN_OPTION_AUTO = 0 // i.e. as defined in the shader the text would rotate to stay upwards range: [-90,90]
 
 var PRIMAL_MINOR  = [0,0,0]
 var MIRROR_MINOR  = [0,0,0]
@@ -468,10 +469,11 @@ proto.draw = function(params) {
 
   var hv_ratio = 0.5 // can have an effect on the ratio between horizontals and verticals when using option 2
 
+  var enableAlign
   var alignDir
 
   function alignTo(i) {
-    alignDir = [0,0,0];
+    alignDir = [0,0,0]
     alignDir[i] = 1
   }
 
@@ -521,8 +523,10 @@ proto.draw = function(params) {
         this._tickAlign[i] = -1
       }
 
-      alignOpt = [this._tickAlign[i], hv_ratio, 0.0]
-      if(alignOpt[0] === 'auto') alignOpt[0] = 1
+      enableAlign = 1;
+
+      alignOpt = [this._tickAlign[i], hv_ratio, enableAlign]
+      if(alignOpt[0] === 'auto') alignOpt[0] = ALIGN_OPTION_AUTO
       else alignOpt[0] = parseInt('' + alignOpt[0])
 
       alignDir = [0,0,0]
@@ -548,14 +552,16 @@ proto.draw = function(params) {
     //Draw labels
     if(this.labelEnable[i]) {
 
-      alignOpt = [this._labelAlign[i], hv_ratio, 0.0]
-      if(alignOpt[0] === 'auto') alignOpt[0] = 1
-      else alignOpt[0] = parseInt('' + alignOpt[0])
-
-      var alignDir = [0,0,0]
+      enableAlign = 0
+      alignDir = [0,0,0]
       if(this.labels[i].length > 4) { // for large label axis enable alignDir to axis
         alignTo(i)
+        enableAlign = 1
       }
+
+      alignOpt = [this._labelAlign[i], hv_ratio, enableAlign]
+      if(alignOpt[0] === 'auto') alignOpt[0] = ALIGN_OPTION_AUTO
+      else alignOpt[0] = parseInt('' + alignOpt[0])
 
       //Add label padding
       for(var j=0; j<3; ++j) {

--- a/lib/shaders/textFrag.glsl
+++ b/lib/shaders/textFrag.glsl
@@ -2,6 +2,10 @@ precision mediump float;
 uniform vec4 color;
 varying float debug;
 void main() {
-  if (debug != 0.0) gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+
+       if (debug == 1.0) gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+  else if (debug == 2.0) gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+  else if (debug == 3.0) gl_FragColor = vec4(0.0, 0.0, 1.0, 1.0);
+  else if (debug == 4.0) gl_FragColor = vec4(1.0, 0.0, 1.0, 1.0);
   else gl_FragColor = color;
 }

--- a/lib/shaders/textFrag.glsl
+++ b/lib/shaders/textFrag.glsl
@@ -1,5 +1,7 @@
 precision mediump float;
 uniform vec4 color;
+varying float debug;
 void main() {
-  gl_FragColor = color;
+  if (debug != 0.0) gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+  else gl_FragColor = color;
 }

--- a/lib/shaders/textFrag.glsl
+++ b/lib/shaders/textFrag.glsl
@@ -1,11 +1,5 @@
 precision mediump float;
 uniform vec4 color;
-varying float debug;
 void main() {
-
-       if (debug == 1.0) gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
-  else if (debug == 2.0) gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
-  else if (debug == 3.0) gl_FragColor = vec4(0.0, 0.0, 1.0, 1.0);
-  else if (debug == 4.0) gl_FragColor = vec4(1.0, 0.0, 1.0, 1.0);
-  else gl_FragColor = color;
+  gl_FragColor = color;
 }

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -27,6 +27,7 @@ const float ONE_AND_HALF_PI = 1.5 * PI;
 
 int option = int(floor(alignOpt.x + 0.001));
 float hv_ratio =       alignOpt.y;
+bool enableAlign =    (alignOpt.z != 0.0);
 
 float mod_angle(float a) {
   return mod(a, PI);
@@ -83,8 +84,9 @@ float applyAlignOption(float rawAngle, float delta) {
                     rawAngle;                // otherwise return back raw input angle
 }
 
-bool enableAlign = (alignDir.x != 0.0) || (alignDir.y != 0.0) || (alignDir.z != 0.0);
-bool isAxisTitle = (    axis.x == 0.0) && (    axis.y == 0.0) && (    axis.z == 0.0);
+bool isAxisTitle = (axis.x == 0.0) &&
+                   (axis.y == 0.0) &&
+                   (axis.z == 0.0);
 
 void main() {
   //Compute world offset
@@ -96,7 +98,7 @@ void main() {
   float axisAngle;
   float clipAngle;
   float flip;
-  
+
   if (enableAlign) {
     axisAngle = (isAxisTitle) ? HALF_PI :
                       computeViewAngle(dataPosition, dataPosition + axis);
@@ -106,7 +108,7 @@ void main() {
     clipAngle += (sin(clipAngle) < 0.0) ? PI : 0.0;
 
     flip = (dot(vec2(cos(axisAngle), sin(axisAngle)),
-                      vec2(sin(clipAngle),-cos(clipAngle))) > 0.0) ? 1.0 : 0.0;
+                vec2(sin(clipAngle),-cos(clipAngle))) > 0.0) ? 1.0 : 0.0;
 
     beta += applyAlignOption(clipAngle, flip * PI);
   }

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -19,14 +19,16 @@ int option = int(floor(alignOpt.x + 0.001));
 float hv_ratio =       alignOpt.y;
 
 float positive_angle(float a) {
-  if (a < 0.0) return a + TWO_PI;
-  return a;
+  return (a < 0.0) ?
+    a + TWO_PI :
+    a;
 }
 
 float look_upwards(float a) {
   float b = positive_angle(a);
-  if ((b > HALF_PI) && (b <= ONE_AND_HALF_PI)) return b - PI;
-  return b;
+  return ((b > HALF_PI) && (b <= ONE_AND_HALF_PI)) ?
+    b - PI :
+    b;
 }
 
 float look_horizontal_or_vertical(float a, float ratio) {

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -25,10 +25,13 @@ float positive_angle(float a) {
 }
 
 float look_upwards(float a) {
+  /*
   float b = positive_angle(a);
   return ((b > HALF_PI) && (b <= ONE_AND_HALF_PI)) ?
     b - PI :
     b;
+  */
+  return a;
 }
 
 float look_horizontal_or_vertical(float a, float ratio) {
@@ -109,13 +112,16 @@ float axisAngle;
     
     clipAngle = computeViewAngle(dataPosition, dataPosition + alignDir);
     axisAngle = computeViewAngle(dataPosition, dataPosition - axis);
-    if (cos(axisAngle) < 0.0) axisAngle = -axisAngle;
+    if (sin(axisAngle) < 0.0) axisAngle = -axisAngle;
     
     if (dot(vec2(cos(clipAngle), sin(clipAngle)), 
             vec2(cos(axisAngle), sin(axisAngle))) < 0.0) {
       //clipAngle = PI + clipAngle;
+      
       debug = 1.0;
     } else debug = 0.0;
+    
+    clipAngle = applyAlignOption(clipAngle);
 
   }    
 

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -25,13 +25,10 @@ float positive_angle(float a) {
 }
 
 float look_upwards(float a) {
-  /*
   float b = positive_angle(a);
   return ((b > HALF_PI) && (b <= ONE_AND_HALF_PI)) ?
     b - PI :
     b;
-  */
-  return a;
 }
 
 float look_horizontal_or_vertical(float a, float ratio) {
@@ -111,6 +108,9 @@ float axisAngle;
     
     
     clipAngle = computeViewAngle(dataPosition, dataPosition + alignDir);
+    
+    clipAngle = applyAlignOption(clipAngle);
+    
     axisAngle = computeViewAngle(dataPosition, dataPosition - axis);
     if (sin(axisAngle) < 0.0) axisAngle = -axisAngle;
     
@@ -121,7 +121,7 @@ float axisAngle;
       debug = 1.0;
     } else debug = 0.0;
     
-    clipAngle = applyAlignOption(clipAngle);
+    
 
   }    
 

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -78,25 +78,46 @@ float applyAlignOption(float rawAngle) {
 
 bool enableAlign = (alignDir.x != 0.0) || (alignDir.y != 0.0) || (alignDir.z != 0.0);
 
-float computeClipAngle(vec3 pnt, vec3 dir) {
-  vec3 startPoint = project(pnt);
-  vec3 endPoint   = project(pnt + dir);
+float computeViewAngle(vec3 a, vec3 b) {
+  vec3 A = project(a);
+  vec3 B = project(b);
 
   return atan(
-    (endPoint.y - startPoint.y) * resolution.y,
-    (endPoint.x - startPoint.x) * resolution.x
+    (B.y - A.y) * resolution.y,
+    (B.x - A.x) * resolution.x
   );
 }
 
+varying float debug;
+
 void main() {
+  
+///////// we could compute this outside main //////////  
+float axisAngle;
+///////////////////////////////////////////////////////
+  
 
   //Compute world offset
   float axisDistance = position.z;
   vec3 dataPosition = axisDistance * axis + offset;
 
-  float clipAngle = (enableAlign) ? 
-    applyAlignOption(computeClipAngle(dataPosition, alignDir)) :
-    angle; // i.e. user defined attributes for each tick
+  float clipAngle = angle; // i.e. user defined attributes for each tick
+  
+  if (enableAlign) {
+    //clipAngle = applyAlignOption(computeViewAngle(dataPosition, alignDir));
+    
+    
+    clipAngle = computeViewAngle(dataPosition, dataPosition + alignDir);
+    axisAngle = computeViewAngle(dataPosition, dataPosition - axis);
+    if (cos(axisAngle) < 0.0) axisAngle = -axisAngle;
+    
+    if (dot(vec2(cos(clipAngle), sin(clipAngle)), 
+            vec2(cos(axisAngle), sin(axisAngle))) < 0.0) {
+      //clipAngle = PI + clipAngle;
+      debug = 1.0;
+    } else debug = 0.0;
+
+  }    
 
   //Compute plane offset
   vec2 planeCoord = position.xy * pixelScale;

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -78,15 +78,13 @@ float applyAlignOption(float rawAngle) {
 
 bool enableAlign = (alignDir.x != 0.0) || (alignDir.y != 0.0) || (alignDir.z != 0.0);
 
-float computeAlignAngle(vec3 pnt, vec3 dir) {
+float computeClipAngle(vec3 pnt, vec3 dir) {
   vec3 startPoint = project(pnt);
   vec3 endPoint   = project(pnt + dir);
 
-  return applyAlignOption(
-    atan(
-      (endPoint.y - startPoint.y) * resolution.y,
-      (endPoint.x - startPoint.x) * resolution.x
-    )
+  return atan(
+    (endPoint.y - startPoint.y) * resolution.y,
+    (endPoint.x - startPoint.x) * resolution.x
   );
 }
 
@@ -97,7 +95,7 @@ void main() {
   vec3 dataPosition = axisDistance * axis + offset;
 
   float clipAngle = (enableAlign) ? 
-    computeAlignAngle(dataPosition, alignDir) :
+    applyAlignOption(computeClipAngle(dataPosition, alignDir)) :
     angle; // i.e. user defined attributes for each tick
 
   //Compute plane offset

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -76,27 +76,27 @@ float applyAlignOption(float rawAngle) {
 
 bool enableAlign = (alignDir.x != 0.0) || (alignDir.y != 0.0) || (alignDir.z != 0.0);
 
+float computeAlignAngle(vec3 pnt, vec3 dir) {
+  vec3 startPoint = project(pnt);
+  vec3 endPoint   = project(pnt + dir);
+
+  return applyAlignOption(
+    atan(
+      (endPoint.y - startPoint.y) * resolution.y,
+      (endPoint.x - startPoint.x) * resolution.x
+    )
+  );
+}
+
 void main() {
 
   //Compute world offset
   float axisDistance = position.z;
   vec3 dataPosition = axisDistance * axis + offset;
 
-  float clipAngle = angle; // i.e. user defined attributes for each tick
-
-  if (enableAlign) {
-    vec3 startPoint = project(dataPosition);
-    vec3 endPoint   = project(dataPosition + alignDir);
-
-    if (endPoint.z < 0.0) endPoint = project(dataPosition - alignDir);
-
-    clipAngle = applyAlignOption(
-      atan(
-        (endPoint.y - startPoint.y) * resolution.y,
-        (endPoint.x - startPoint.x) * resolution.x
-      )
-    );
-  }
+  float clipAngle = (enableAlign) ? 
+    computeAlignAngle(dataPosition, alignDir) :
+    angle; // i.e. user defined attributes for each tick
 
   //Compute plane offset
   vec2 planeCoord = position.xy * pixelScale;

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -107,7 +107,7 @@ void main() {
     float flip = (dot(vec2(cos(axisAngle), sin(axisAngle)),
                       vec2(sin(clipAngle),-cos(clipAngle))) > 0.0) ? 1.0 : 0.0;
 
-    beta = applyAlignOption(clipAngle, flip * PI);
+    beta += applyAlignOption(clipAngle, flip * PI);
   }
 
   //Compute plane offset

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -16,17 +16,16 @@ const float HALF_PI = 0.5 * PI;
 const float ONE_AND_HALF_PI = 1.5 * PI;
 
 int option = int(floor(alignOpt.x + 0.001));
-float up_tolerance =   alignOpt.y;
-float hv_ratio =       alignOpt.z;
+float hv_ratio =       alignOpt.y;
 
 float positive_angle(float a) {
   if (a < 0.0) return a + TWO_PI;
   return a;
 }
 
-float look_upwards(float a, float tolerance) {
+float look_upwards(float a) {
   float b = positive_angle(a);
-  if ((b > HALF_PI + tolerance) && (b <= ONE_AND_HALF_PI + tolerance)) return b - PI;
+  if ((b > HALF_PI) && (b <= ONE_AND_HALF_PI)) return b - PI;
   return b;
 }
 
@@ -52,7 +51,7 @@ float look_round_n_directions(float a, int n) {
   float b = positive_angle(a);
   float div = TWO_PI / float(n);
   float c = roundTo(b, div);
-  return look_upwards(c, up_tolerance);
+  return look_upwards(c);
 }
 
 float applyAlignOption(float rawAngle) {
@@ -65,7 +64,7 @@ float applyAlignOption(float rawAngle) {
     return rawAngle;
   } else if (option == 1) {
     // option 1: use free angle, but flip when reversed
-    return look_upwards(rawAngle, up_tolerance);
+    return look_upwards(rawAngle);
   } else if (option == 2) {
     // option 2: horizontal or vertical
     return look_horizontal_or_vertical(rawAngle, hv_ratio);
@@ -91,7 +90,7 @@ void main() {
 
     if (endPoint.z < 0.0) endPoint = project(dataPosition - alignDir);
 
-    clipAngle += applyAlignOption(
+    clipAngle = applyAlignOption(
       atan(
         (endPoint.y - startPoint.y) * resolution.y,
         (endPoint.x - startPoint.x) * resolution.x

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -91,28 +91,25 @@ float computeViewAngle(vec3 a, vec3 b) {
 varying float debug;
 
 void main() {
-  
-///////// we could compute this outside main //////////  
-float axisAngle;
-///////////////////////////////////////////////////////
-  
 
   //Compute world offset
   float axisDistance = position.z;
   vec3 dataPosition = axisDistance * axis + offset;
 
+  float axisAngle;
   float clipAngle = angle; // i.e. user defined attributes for each tick
   
   if (enableAlign) {
     //clipAngle = applyAlignOption(computeViewAngle(dataPosition, alignDir));
-    
-    
+
     clipAngle = computeViewAngle(dataPosition, dataPosition + alignDir);
     
     clipAngle = applyAlignOption(clipAngle);
     
-    axisAngle = computeViewAngle(dataPosition, dataPosition - axis);
-    if (sin(axisAngle) < 0.0) axisAngle = -axisAngle;
+    axisAngle = computeViewAngle(dataPosition, dataPosition - offset);
+    if (sin(axisAngle) < 0.0) {
+      axisAngle = -axisAngle;
+    }
     
     if (dot(vec2(cos(clipAngle), sin(clipAngle)), 
             vec2(cos(axisAngle), sin(axisAngle))) < 0.0) {
@@ -120,8 +117,6 @@ float axisAngle;
       
       debug = 1.0;
     } else debug = 0.0;
-    
-    
 
   }    
 

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -113,7 +113,7 @@ void main() {
     
     if (dot(vec2(cos(clipAngle), sin(clipAngle)), 
             vec2(cos(axisAngle), sin(axisAngle))) < 0.0) {
-      //clipAngle = PI + clipAngle;
+      clipAngle = PI + clipAngle;
       
       debug = 1.0;
     } else debug = 0.0;


### PR DESCRIPTION
This PR improves automatic alignment of ticks on 3D axes. 
In the [earlier work](https://github.com/plotly/plotly.js/pull/3103) it was made possible for the ticks on an axis to align themselves in two different directions and stay upwards (i.e. the default behavior). 
In addition other options for example finding the best single orientation for each axis (depending on the camera position and orientation) is now available in the vertex shader. Those options could be available to the user through Plotly API in future.
Please refer to [Plotly PR 3131](https://github.com/plotly/plotly.js/pull/3131) for more info.
@alexcjohnson 