### PR TITLE
Changes required in gl-axes3d module for implementing break lines, sub & superscripts as well as bold & italic styles

### DIFF
--- a/axes.js
+++ b/axes.js
@@ -49,8 +49,8 @@ function Axes(gl) {
   this.labelEnable    = [ true, true, true ]
   this.labelFont      = 'sans-serif'
   this.labelSize      = [ 20, 20, 20 ]
-  this._labelAngle     = [ 0, 0, 0 ]
-  this._labelAlign     = [ 'auto', 'auto', 'auto' ]
+  this.labelAngle     = [ 0, 0, 0 ]
+  this.labelAlign     = [ 'auto', 'auto', 'auto' ]
   this.labelColor     = [ [0,0,0,1], [0,0,0,1], [0,0,0,1] ]
   this.labelPad       = [ 10, 10, 10 ]
 
@@ -559,7 +559,7 @@ proto.draw = function(params) {
         enableAlign = 1
       }
 
-      alignOpt = [this._labelAlign[i], hv_ratio, enableAlign]
+      alignOpt = [this.labelAlign[i], hv_ratio, enableAlign]
       if(alignOpt[0] === 'auto') alignOpt[0] = ALIGN_OPTION_AUTO
       else alignOpt[0] = parseInt('' + alignOpt[0])
 
@@ -573,7 +573,7 @@ proto.draw = function(params) {
       this._text.drawLabel(
         i,
         this.labelSize[i],
-        this._labelAngle[i],
+        this.labelAngle[i],
         offset,
         this.labelColor[i],
         [0,0,0],

--- a/lib/text.js
+++ b/lib/text.js
@@ -57,7 +57,7 @@ proto.unbind = function() {
 proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
   var data = []
 
-  function addItem(t, text, font, size, breakLines, lineSpacing) {
+  function addItem(t, text, font, size, lineSpacing, styletags) {
     var fontcache = __TEXT_CACHE[font]
     if(!fontcache) {
       fontcache = __TEXT_CACHE[font] = {}
@@ -69,8 +69,8 @@ proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
         font: font,
         textAlign: 'center',
         textBaseline: 'middle',
-        breakLines: breakLines,
-        lineSpacing: lineSpacing
+        lineSpacing: lineSpacing,
+        styletags: styletags
       })
     }
     var scale = (size || 12) / 12
@@ -99,8 +99,8 @@ proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
       labels[d],
       labelFont[d],
       12, // labelFontSize
-      true,
-      1.25 // lineSpacing
+      1.25, // lineSpacing
+      {breaklines:true, bolds: true, italics: true, subscripts:true, superscripts:true}
     )
     labelCount[d] = ((data.length/VERTEX_SIZE)|0) - labelOffset[d]
 
@@ -115,7 +115,8 @@ proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
         ticks[d][i].text,
         ticks[d][i].font || tickFont,
         ticks[d][i].fontSize || 12,
-        false
+        1.25, // lineSpacing
+        {breaklines:true, bolds: true, italics: true, subscripts:true, superscripts:true}
       )
     }
     tickCount[d] = ((data.length/VERTEX_SIZE)|0) - tickOffset[d]
@@ -171,7 +172,7 @@ function tryVectorizeText(text, options) {
   try {
     return vectorizeText(text, options)
   } catch(e) {
-    console.warn('error vectorizing text:', e)
+    console.warn('error vectorizing text:"' + text + '" error:', e)
     return {
       cells: [],
       positions: []

--- a/lib/text.js
+++ b/lib/text.js
@@ -98,7 +98,14 @@ proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
 
     //Generate label
     labelOffset[d] = (data.length/VERTEX_SIZE)|0
-    addItem(0.5*(bounds[0][d]+bounds[1][d]), labels[d], labelFont[d], true, 1.25)
+    addItem(
+      0.5*(bounds[0][d]+bounds[1][d]),
+      labels[d],
+      labelFont[d],
+      12, // labelFontSize
+      true,
+      1.25 // lineSpacing
+    )
     labelCount[d] = ((data.length/VERTEX_SIZE)|0) - labelOffset[d]
 
     //Generate sprites for tick marks

--- a/lib/text.js
+++ b/lib/text.js
@@ -59,7 +59,7 @@ proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
   var gl = this.gl
   var data = []
 
-  function addItem(t, text, font, size) {
+  function addItem(t, text, font, size, breakLines, lineSpacing) {
     var fontcache = __TEXT_CACHE[font]
     if(!fontcache) {
       fontcache = __TEXT_CACHE[font] = {}
@@ -70,7 +70,9 @@ proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
         triangles: true,
         font: font,
         textAlign: 'center',
-        textBaseline: 'middle'
+        textBaseline: 'middle',
+        breakLines: breakLines,
+        lineSpacing: lineSpacing
       })
     }
     var scale = (size || 12) / 12
@@ -96,7 +98,7 @@ proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
 
     //Generate label
     labelOffset[d] = (data.length/VERTEX_SIZE)|0
-    addItem(0.5*(bounds[0][d]+bounds[1][d]), labels[d], labelFont[d])
+    addItem(0.5*(bounds[0][d]+bounds[1][d]), labels[d], labelFont[d], true, 1.25)
     labelCount[d] = ((data.length/VERTEX_SIZE)|0) - labelOffset[d]
 
     //Generate sprites for tick marks
@@ -109,7 +111,9 @@ proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
         ticks[d][i].x,
         ticks[d][i].text,
         ticks[d][i].font || tickFont,
-        ticks[d][i].fontSize || 12)
+        ticks[d][i].fontSize || 12,
+        false
+      )
     }
     tickCount[d] = ((data.length/VERTEX_SIZE)|0) - tickOffset[d]
   }

--- a/lib/text.js
+++ b/lib/text.js
@@ -90,6 +90,14 @@ proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
   var tickCount   = [0,0,0]
   var labelOffset = [0,0,0]
   var labelCount  = [0,0,0]
+  var lineSpacing = 1.25
+  var styletags = {
+    breaklines:true,
+    bolds: true,
+    italics: true,
+    subscripts:true,
+    superscripts:true
+  }
   for(var d=0; d<3; ++d) {
 
     //Generate label
@@ -99,8 +107,8 @@ proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
       labels[d],
       labelFont[d],
       12, // labelFontSize
-      1.25, // lineSpacing
-      {breaklines:true, bolds: true, italics: true, subscripts:true, superscripts:true}
+      lineSpacing,
+      styletags
     )
     labelCount[d] = ((data.length/VERTEX_SIZE)|0) - labelOffset[d]
 
@@ -115,8 +123,8 @@ proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
         ticks[d][i].text,
         ticks[d][i].font || tickFont,
         ticks[d][i].fontSize || 12,
-        1.25, // lineSpacing
-        {breaklines:true, bolds: true, italics: true, subscripts:true, superscripts:true}
+        lineSpacing,
+        styletags
       )
     }
     tickCount[d] = ((data.length/VERTEX_SIZE)|0) - tickOffset[d]

--- a/lib/text.js
+++ b/lib/text.js
@@ -17,7 +17,6 @@ globals.__TEXT_CACHE = {}
 //
 
 var VERTEX_SIZE = 3
-var VERTEX_STRIDE = VERTEX_SIZE * 4
 
 function TextSprites(
   gl,
@@ -56,7 +55,6 @@ proto.unbind = function() {
 }
 
 proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
-  var gl = this.gl
   var data = []
 
   function addItem(t, text, font, size, breakLines, lineSpacing) {
@@ -78,8 +76,6 @@ proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
     var scale = (size || 12) / 12
     var positions = mesh.positions
     var cells = mesh.cells
-    var lo = [ Infinity, Infinity]
-    var hi = [-Infinity,-Infinity]
     for(var i=0, nc=cells.length; i<nc; ++i) {
       var c = cells[i]
       for(var j=2; j>=0; --j) {

--- a/lib/text.js
+++ b/lib/text.js
@@ -96,7 +96,7 @@ proto.update = function(bounds, labels, labelFont, ticks, tickFont) {
 
     //Generate label
     labelOffset[d] = (data.length/VERTEX_SIZE)|0
-    addItem(0.5*(bounds[0][d]+bounds[1][d]), labels[d], labelFont)
+    addItem(0.5*(bounds[0][d]+bounds[1][d]), labels[d], labelFont[d])
     labelCount[d] = ((data.length/VERTEX_SIZE)|0) - labelOffset[d]
 
     //Generate sprites for tick marks

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,7 @@
     },
     "box-intersect": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
       "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
       "requires": {
         "bit-twiddle": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,8 +1626,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
-      "from": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
+      "version": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
+      "from": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,8 +1626,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
-      "from": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.2.0.tgz",
+      "integrity": "sha512-N3eldFPkXY7mVK1aBuKPdQKYerBSPEAf+4Tl6DGdnVb1MZ8buD9SKv5TUCyRCEe5KblC56MoJcmf0I/IyGjOGQ==",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,7 @@
     },
     "box-intersect": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
       "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
       "requires": {
         "bit-twiddle": "^1.0.2",
@@ -1626,8 +1626,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11",
-      "from": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11",
+      "version": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e",
+      "from": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,8 +1626,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
-      "from": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
+      "version": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
+      "from": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,7 @@
     },
     "box-intersect": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
       "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
       "requires": {
         "bit-twiddle": "^1.0.2",
@@ -1626,8 +1626,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
-      "from": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
+      "version": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
+      "from": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1506,11 +1506,6 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
-    "superscript-text": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
-      "integrity": "sha1-58snUlZzYN9QvrBhDOjfPXHY39g="
-    },
     "surface-nets": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/surface-nets/-/surface-nets-1.0.2.tgz",
@@ -1631,15 +1626,14 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396",
-      "from": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396",
+      "version": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86",
+      "from": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",
         "ndarray": "^1.0.11",
         "planar-graph-to-polyline": "^1.0.0",
         "simplify-planar-graph": "^2.0.1",
-        "superscript-text": "^1.0.0",
         "surface-nets": "^1.0.0",
         "triangulate-polyline": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1506,6 +1506,11 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
+    "superscript-text": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
+      "integrity": "sha1-58snUlZzYN9QvrBhDOjfPXHY39g="
+    },
     "surface-nets": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/surface-nets/-/surface-nets-1.0.2.tgz",
@@ -1626,14 +1631,15 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#e1aacb074fd846249e9affea04b9f32f2ad40652",
-      "from": "git://github.com/archmoj/vectorize-text.git#e1aacb074fd846249e9affea04b9f32f2ad40652",
+      "version": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396",
+      "from": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",
         "ndarray": "^1.0.11",
         "planar-graph-to-polyline": "^1.0.0",
         "simplify-planar-graph": "^2.0.1",
+        "superscript-text": "^1.0.0",
         "surface-nets": "^1.0.0",
         "triangulate-polyline": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,8 +1626,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
-      "from": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
+      "version": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
+      "from": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,7 @@
     },
     "box-intersect": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
       "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
       "requires": {
         "bit-twiddle": "^1.0.2",
@@ -1626,8 +1626,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e",
-      "from": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e",
+      "version": "git://github.com/archmoj/vectorize-text.git#e1aacb074fd846249e9affea04b9f32f2ad40652",
+      "from": "git://github.com/archmoj/vectorize-text.git#e1aacb074fd846249e9affea04b9f32f2ad40652",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,8 +1626,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
-      "from": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
+      "version": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
+      "from": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,8 +1626,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
-      "from": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e",
+      "version": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
+      "from": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,8 +1626,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
-      "from": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12",
+      "version": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
+      "from": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,7 @@
     },
     "box-intersect": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
       "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
       "requires": {
         "bit-twiddle": "^1.0.2",
@@ -1626,9 +1626,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.0.2.tgz",
-      "integrity": "sha1-BasWMOQJ83eWTiuSBbLVWakvYNg=",
+      "version": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11",
+      "from": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,8 +1626,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
-      "from": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb",
+      "version": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
+      "from": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,8 +1626,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vectorize-text": {
-      "version": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86",
-      "from": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86",
+      "version": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
+      "from": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glslify": "^6.1.0",
     "robust-orientation": "^1.1.3",
     "split-polygon": "^1.0.0",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glslify": "^6.1.0",
     "robust-orientation": "^1.1.3",
     "split-polygon": "^1.0.0",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glslify": "^6.1.0",
     "robust-orientation": "^1.1.3",
     "split-polygon": "^1.0.0",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#3a52ec1d3a3f624460963ba408fda3b5d9b272e2"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glslify": "^6.1.0",
     "robust-orientation": "^1.1.3",
     "split-polygon": "^1.0.0",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#c825b5b7b57d92b6e36f93ce1c07d7a88d4fee86"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glslify": "^6.1.0",
     "robust-orientation": "^1.1.3",
     "split-polygon": "^1.0.0",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#e1aacb074fd846249e9affea04b9f32f2ad40652"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glslify": "^6.1.0",
     "robust-orientation": "^1.1.3",
     "split-polygon": "^1.0.0",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#8c78af829e90688c6a752821ec171c0082be4c10"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glslify": "^6.1.0",
     "robust-orientation": "^1.1.3",
     "split-polygon": "^1.0.0",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#e1aacb074fd846249e9affea04b9f32f2ad40652"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#454a9d47bbc67f7c5fdabe5faa6abf32a1d7c396"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glslify": "^6.1.0",
     "robust-orientation": "^1.1.3",
     "split-polygon": "^1.0.0",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glslify": "^6.1.0",
     "robust-orientation": "^1.1.3",
     "split-polygon": "^1.0.0",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#9dc8842e941e39a982aa4444873181e7409e4b1e"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glslify": "^6.1.0",
     "robust-orientation": "^1.1.3",
     "split-polygon": "^1.0.0",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#ed1cadb6e8b6506cb224d14d1cce9bfadd483887"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glslify": "^6.1.0",
     "robust-orientation": "^1.1.3",
     "split-polygon": "^1.0.0",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#115c0f4371984fa3d8ade5b07041ea1116e420bb"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#457db88a269e6412c6f6007f1ba88d06bdfbc08c"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glslify": "^6.1.0",
     "robust-orientation": "^1.1.3",
     "split-polygon": "^1.0.0",
-    "vectorize-text": "^3.0.0"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#1afb95965a67b776f3ad349e934c1024dc87eb11"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glslify": "^6.1.0",
     "robust-orientation": "^1.1.3",
     "split-polygon": "^1.0.0",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0"
+    "vectorize-text": "^3.2.0"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glslify": "^6.1.0",
     "robust-orientation": "^1.1.3",
     "split-polygon": "^1.0.0",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#9f1e1cef3bc7f74c6c17cd8bdbe7a8ad20028e12"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#741a0224ef4d6560f0b81bb1267ea93071d45e83"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "glslify": "^6.1.0",
     "robust-orientation": "^1.1.3",
     "split-polygon": "^1.0.0",
-    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#6fe3635932eb8835f2934756798be2d349e2089e"
+    "vectorize-text": "git://github.com/archmoj/vectorize-text.git#7e13665e8e1b60edc53fce925acceed67d93e3f0"
   },
   "devDependencies": {
     "game-shell-orbit-camera": "^1.0.0",


### PR DESCRIPTION
This PR is making use of the latest options in `vectorize-text` that enables tags namely < b > < i > < sup > < sub> and < br > within webGL texts.
Please also refer to [Plotly PR 3207](https://github.com/plotly/plotly.js/pull/3207) for more information.
@etpinard 
@alexcjohnson 