### PR TITLE
adjust tick distances in perspective views - gl-axes3d

### DIFF
--- a/lib/cube.js
+++ b/lib/cube.js
@@ -4,12 +4,10 @@ module.exports = getCubeEdges
 
 var bits      = require('bit-twiddle')
 var multiply  = require('gl-mat4/multiply')
-var invert    = require('gl-mat4/invert')
 var splitPoly = require('split-polygon')
 var orient    = require('robust-orientation')
 
 var mvp        = new Array(16)
-var imvp       = new Array(16)
 var pCubeVerts = new Array(8)
 var cubeVerts  = new Array(8)
 var x          = new Array(3)
@@ -86,7 +84,7 @@ function getCubeEdges(model, view, projection, bounds) {
   //Concatenate matrices
   multiply(mvp, view, model)
   multiply(mvp, projection, mvp)
-  
+
   //First project cube vertices
   var ptr = 0
   for(var i=0; i<2; ++i) {
@@ -115,7 +113,7 @@ function getCubeEdges(model, view, projection, bounds) {
       } else if(cubeVerts[i][2] < cubeVerts[closest][2]) {
         closest = i
       }
-    }    
+    }
   }
 
   if(closest < 0) {
@@ -143,15 +141,15 @@ function getCubeEdges(model, view, projection, bounds) {
           closest |= 1<<d
         }
         continue
-      } 
+      }
       for(var s=0; s<2; ++s) {
         var f0 = (s<<d)
         var f1 = f0 + (s << u) + ((1-s) << v)
-        var f2 = f0 + ((1-s) << u) + (s << v)    
+        var f2 = f0 + ((1-s) << u) + (s << v)
         var o = polygonArea([
-            pCubeVerts[f0], 
-            pCubeVerts[f1], 
-            pCubeVerts[f2], 
+            pCubeVerts[f0],
+            pCubeVerts[f1],
+            pCubeVerts[f2],
             pCubeVerts[f0+(1<<u)+(1<<v)]])
         if(s) {
           o0 = o

--- a/properties.js
+++ b/properties.js
@@ -114,7 +114,7 @@ i_loop:
           poly.push(x.slice())
         }
       }
-      for(var j=0; j<frustum.length; ++j) {
+      for(var j=4; j===4; ++j) { // Note: using only near plane here.
         if(poly.length === 0) {
           continue i_loop
         }


### PR DESCRIPTION
When computing the tick distances all the data in front of the camera should be used in order to avoid or undefined results. Therefore in this PR only the near clipping is applied while left, right, top, bottom, far perspective clipping planes are disabled in calculations of axis ranges.
Please refer to this [Plotly PR](https://github.com/plotly/plotly.js/pull/3308) for more info.
@etpinard 