### PR TITLE
Improve numerical stability of projection

### DIFF
--- a/lib/shaders/backgroundVert.glsl
+++ b/lib/shaders/backgroundVert.glsl
@@ -19,7 +19,7 @@ void main() {
     vec3 minRange = min(bounds[0], bounds[1]);
     vec3 maxRange = max(bounds[0], bounds[1]);
     vec3 nPosition = mix(minRange, maxRange, 0.5 * (position + 1.0));
-    gl_Position = projection * view * model * vec4(nPosition, 1.0);
+    gl_Position = projection * (view * (model * vec4(nPosition, 1.0)));
   } else {
     gl_Position = vec4(0,0,0,0);
   }

--- a/lib/shaders/lineVert.glsl
+++ b/lib/shaders/lineVert.glsl
@@ -8,7 +8,7 @@ uniform float lineWidth;
 uniform vec2 screenShape;
 
 vec3 project(vec3 p) {
-  vec4 pp = projection * view * model * vec4(p, 1.0);
+  vec4 pp = projection * (view * (model * vec4(p, 1.0)));
   return pp.xyz / max(pp.w, 0.0001);
 }
 

--- a/lib/shaders/textVert.glsl
+++ b/lib/shaders/textVert.glsl
@@ -8,7 +8,7 @@ uniform float scale, angle, pixelScale;
 uniform vec2 resolution;
 
 vec3 project(vec3 p) {
-  vec4 pp = projection * view * model * vec4(p, 1.0);
+  vec4 pp = projection * (view * (model * vec4(p, 1.0)));
   return pp.xyz / max(pp.w, 0.0001);
 }
 


### PR DESCRIPTION
I was investigating this behaviour in plotly: https://github.com/plotly/plotly.js/issues/3306
and found that, even looking at the first "good" provided example https://jsfiddle.net/Lv4qpoyu/3/ it is not well usable, because the axis labels jump around a lot while rotating the scene. When decreasing the visible time range in that fiddle even more, the jumping even gets chaotic, making the plot unusable.

I then kept looking for the cause and it appears that when we are dealing with large position values (like the UTC timestamps) that are offset by the model matrix, the current implementation is numerically unstable because the project operation is done left to right, multiplying the matrices before applying them to the position.

For good measure, I also added another pair of braces to replace the `projection*view` matrix-matrix-multiplication with matrix-vector multiplications, which should be faster and more stable, even though I did not see an effect.

I tested this change by patching the dist/plotly.js file and applying my changes to the shader strings, which greatly improved the positioning of the axis labels.

If you accept this change, I can also create similar pull requests in the different gl-vis repositories where similar constructs are used.